### PR TITLE
Fix for OUJS

### DIFF
--- a/ob.meta.js
+++ b/ob.meta.js
@@ -19,7 +19,7 @@
 // @author                   Sebbe <sebbe@omertabeyond.com>
 // @author                   Brainscrewer <brainscrewer@omertabeyond.com>
 // @author                   semitom <tom.gankema@gmail.com>
-// @license                  GNU General Public License v3
+// @license                  GPL-3.0
 // @contributionURL          https://www.patreon.com/bePatron?u=7718354
 // @contributionAmount       $1.00
 // @encoding                 UTF-8

--- a/ob.user.js
+++ b/ob.user.js
@@ -37,7 +37,7 @@
 // @author                   Sebbe <sebbe@omertabeyond.com>
 // @author                   Brainscrewer <brainscrewer@omertabeyond.com>
 // @author                   semitom <tom.gankema@gmail.com>
-// @license                  GNU General Public License v3
+// @license                  GPL-3.0
 // @contributionURL          https://www.patreon.com/bePatron?u=7718354
 // @contributionAmount       $1.00
 // @encoding                 UTF-8


### PR DESCRIPTION
Hey all,

OUJS has made a change recently to require SPDX codes for OSI approved licensing.

In order to improve the appearance of your script homepages it would be appreciated if you could modify all of your affected scripts. It's the same code in the upper right hand corner of GH here. :)

The SPDX short identifier for `MIT` is that... a few of your other scripts have `The MIT License (MIT)`.

Until this change is made you will be unable to update those affected scripts.

Thanks,
OUJS Staff