### PR TITLE
Fix for OUJS

### DIFF
--- a/ob.meta.js
+++ b/ob.meta.js
@@ -19,7 +19,7 @@
 // @author                   Sebbe <sebbe@omertabeyond.com>
 // @author                   Brainscrewer <brainscrewer@omertabeyond.com>
 // @author                   semitom <tom.gankema@gmail.com>
-// @license                  GPL-3.0
+// @license                  GPL-3.0-or-later
 // @contributionURL          https://www.patreon.com/bePatron?u=7718354
 // @contributionAmount       $1.00
 // @encoding                 UTF-8

--- a/ob.user.js
+++ b/ob.user.js
@@ -37,7 +37,7 @@
 // @author                   Sebbe <sebbe@omertabeyond.com>
 // @author                   Brainscrewer <brainscrewer@omertabeyond.com>
 // @author                   semitom <tom.gankema@gmail.com>
-// @license                  GPL-3.0
+// @license                  GPL-3.0-or-later
 // @contributionURL          https://www.patreon.com/bePatron?u=7718354
 // @contributionAmount       $1.00
 // @encoding                 UTF-8


### PR DESCRIPTION
Hey again.

Our dependency for SPDX has moved to the latest release version and includes the `-or-later` option which matches the license text at [/OmertaBeyond/OBv2/blob/`f83a969`/ob.user.js#L7](https://github.com/OmertaBeyond/OBv2/blob/f83a969bf97260e6cc70d007cd985f077b1104dd/ob.user.js#L7)

Here's the fix to have the server accept it. Please note that the main individual account needs to GH login to reconsent *(GDPR stuff)* and enable the webhook if that is used.

Thanks for the the consideration again,
OUJS Staff

P.S. Hopefully they don't change the short identifiers for a long, long, long time. :) And you all are one of the few I'm hunting down directly this round.

Historical Ref #122